### PR TITLE
Add /unrelated

### DIFF
--- a/cogs/utility.py
+++ b/cogs/utility.py
@@ -154,7 +154,6 @@ class utility(commands.Cog):
         await self.send_action_log(action_id=action_id, post_mention=post.mention, tags=tags, context="/solved used")
         task = asyncio.create_task(self.close_post(post=post))
         self.close_tasks[post] = task
-        return task
 
     async def lock_unrelated_post(self, post: discord.Thread) -> None:
         """
@@ -166,7 +165,6 @@ class utility(commands.Cog):
         await self.send_action_log(action_id=action_id, post_mention=post.mention, tags=solved, context="/unrelated used")
         task = asyncio.create_task(self.close_post(post=post, close_delay=600))
         self.close_tasks[post] = task
-        return task
 
     async def unsolve_post(self, post: discord.Thread) -> None:
         """  


### PR DESCRIPTION
Adds the `/unrelated` command. It is also available as a prefix command under the same name
Due to the amount of posts that get created nowadays that are about roblox or something alike i decided to add this command for a more "professional" approach to closing such posts

This command will:
- Immediately lock the post
- Override the tags to solved
- Send a message pinging the post creator that their question/issue is unrelated to sapphire or appeal.gg
- Archive the post 10 minutes after it was locked

With this i also added the function `lock_unrelated_post` which handles the lock and archive logic, and updated the `close_post` function to accept a variable close_delay

This is what the information message looks like, feel free to change it's contents if you can think of better wording.
![Screenshot 2025-07-07 174441](https://github.com/user-attachments/assets/b93592cb-a9fd-43b5-8d6a-00fa85383149)
