### PR TITLE
Refactor Reminders + Close abandoned posts

### DIFF
--- a/SH/cogs/autoadd.py
+++ b/SH/cogs/autoadd.py
@@ -29,6 +29,7 @@ DEVELOPERS_ROLE_ID = int(os.getenv("DEVELOPERS_ROLE_ID"))
 class ConfirmCloseButtons(ui.ActionRow):
     def __init__(self):
         super().__init__()
+        self.is_owner: bool = False
 
     @ui.button(label="Mark as solved", style=discord.ButtonStyle.green, custom_id="auto-close-confirm")
     async def on_confirm_click(self, interaction: discord.Interaction[MyClient], _: ui.Button):
@@ -53,14 +54,21 @@ class ConfirmCloseButtons(ui.ActionRow):
 
 
     @ui.button(label="Cancel", style=discord.ButtonStyle.red, custom_id="auto-close-cancel")
-    async def on_cancel_click(self, interaction: discord.Interaction, button: ui.Button):
+    async def on_cancel_click(self, interaction: discord.Interaction[MyClient], _: ui.Button):
         text_display: discord.TextDisplay = ui.LayoutView.from_message(interaction.message).find_item(10) # type: ignore
         new_view = discord.ui.LayoutView().add_item(ui.Container(ui.TextDisplay(f"~~{text_display.content}~~"), ui.Separator(), ui.TextDisplay(f"-# Cancelled by {interaction.user}")))
         await interaction.response.edit_message(view=new_view)
 
+        if self.is_owner:
+            description = "Please send a message here explaining what you still need help with."
+            footer = f"-# When the issue is resolved, you may use </solved:{await interaction.client.get_solved_id()}> to mark it as solved."
+            view = ui.LayoutView().add_item(ui.Container(ui.TextDisplay(description), ui.Separator(visible=True), 
+                                                            ui.TextDisplay(footer)))
+            await interaction.message.reply(view=view)
+
     async def interaction_check(self, interaction: discord.Interaction[MyClient]) -> bool:
-        is_owner = interaction.user.id == interaction.channel.owner_id or interaction.user.id == await get_post_creator_id(interaction.channel_id)
-        if not (is_owner or interaction.user.get_role(EXPERTS_ROLE_ID) or interaction.user.get_role(MODERATORS_ROLE_ID) or interaction.user.get_role(DEVELOPERS_ROLE_ID)):
+        self.is_owner = interaction.user.id == interaction.channel.owner_id or interaction.user.id == await get_post_creator_id(interaction.channel_id)
+        if not (self.is_owner or interaction.user.get_role(EXPERTS_ROLE_ID) or interaction.user.get_role(MODERATORS_ROLE_ID) or interaction.user.get_role(DEVELOPERS_ROLE_ID)):
             await interaction.response.send_message(content=f"Only <@&{EXPERTS_ROLE_ID}>, <@&{MODERATORS_ROLE_ID}>, <@&{DEVELOPERS_ROLE_ID}> and the post creator can use this!", ephemeral=True)
             return False
         return True
@@ -85,14 +93,10 @@ class ConfirmCloseView(ui.LayoutView):
 class autoadd(commands.Cog):
     def __init__(self, client: MyClient):
         self.client = client
-        self.close_abandoned_posts.start()
         
     @commands.Cog.listener('on_ready')
     async def add_persistent_view(self):
         self.client.add_view(ConfirmCloseView())
-
-    def cog_unload(self):
-        self.close_abandoned_posts.cancel()
 
     sent_post_ids = [] # A list of posts where the bot sent a suggestion message to use /solved
 
@@ -158,30 +162,6 @@ class autoadd(commands.Cog):
             await message.channel.edit(applied_tags=tags, reason=f"ID: {action_id}. Auto-remove unanswered tag and replace with not solved tag")
             await self.client.send_log(ALERTS_THREAD_ID, action_id=action_id, post_mention=message.channel.mention, tags=tags, context="Replace unanswered tag with not solved")
 
-    @tasks.loop(hours=1)
-    async def close_abandoned_posts(self):
-        support = self.client.get_channel(SUPPORT_CHANNEL_ID)
-        if not support:
-            return
-        for post in await support.guild.active_threads():
-            if post.parent_id != SUPPORT_CHANNEL_ID or post.locked or NEED_DEV_REVIEW_TAG_ID in post._applied_tags:
-                continue
-            owner = post.guild.get_member(await get_post_creator_id(post.id)) or post.owner
-            if owner is not None: # post owner/creator will be None if they left the server
-                continue
-
-            tags = [support.get_tag(SOLVED_TAG_ID)]
-            cb = support.get_tag(CUSTOM_BRANDING_TAG_ID)
-            appeal = support.get_tag(APPEAL_GG_TAG_ID)
-            if CUSTOM_BRANDING_TAG_ID in post._applied_tags: 
-                tags.append(cb)
-            if APPEAL_GG_TAG_ID in post._applied_tags:
-                tags.append(appeal)
-            action_id = generate_random_id()
-            await post.send("This post was automatically marked as **Solved** because the post creator left the server.")
-            await post.edit(archived=True, reason=f"ID: {action_id}. User left server, auto close post", applied_tags=tags)
-            await self.client.send_log(ALERTS_THREAD_ID, action_id=action_id, post_mention=post.mention, tags=tags, context="Post creator left the server")
-
     @commands.Cog.listener('on_raw_message_delete')
     async def suggest_closing_post(self, payload: discord.RawMessageDeleteEvent):
         message_channel = self.client.get_channel(payload.channel_id)
@@ -197,14 +177,6 @@ class autoadd(commands.Cog):
                 await message_channel.send(
                     view=ConfirmCloseView(post_author=owner_id)
                 )
-
-    @close_abandoned_posts.before_loop
-    async def wait_until_ready(self):
-        await self.client.wait_until_ready()
-
-    @close_abandoned_posts.error
-    async def close_abandoned_posts_error(self, error: BaseException):
-        await self.client.send_unhandled_error(error, task=self.close_abandoned_posts)
 
 async def setup(client: MyClient):
     await client.add_cog(autoadd(client))

--- a/SH/cogs/remind.py
+++ b/SH/cogs/remind.py
@@ -127,7 +127,7 @@ class Reminders(commands.Cog):
     async def cog_unload(self):
         self.reminders_loop.cancel()
 
-    @tasks.loop(hours=1)
+    @tasks.loop(seconds=30)
     async def reminders_loop(self):
         """
         This task consists of 3 'loops':
@@ -181,8 +181,11 @@ class Reminders(commands.Cog):
         posts_to_add: list[int] = []
         pending_posts: list[int] = await get_pending_posts() # Cache the list to avoid DB calls every iteration of the loop
         for post in posts:
-            now_dt = time_snowflake(datetime.now(UTC))
-            more_than_day = check_time_more_than(snowflake_time(post.last_message_id or now_dt).timestamp(),
+            if not post.last_message_id: # no message was ever sent?? This should realistically never happen for threads
+                continue
+
+            last_msg_timestamp = snowflake_time(post.last_message_id).timestamp()
+            more_than_day = check_time_more_than(last_msg_timestamp,
                                                 timedelta(days=1)) # Check time before making any further API/DB calls
             if not more_than_day or post.id in pending_posts:
                 continue
@@ -190,25 +193,24 @@ class Reminders(commands.Cog):
                 continue
 
             post_author_id = await get_post_creator_id(post.id) or post.owner_id
+            
+            # If the last message > 3d, we send the reminder regardless of other requirements
+            if check_time_more_than(last_msg_timestamp, timedelta(days=3)):
+                await post.send(view=CloseNowView(post_author_id, time_ago="3 days"))
+                posts_to_add.append(post.id)
+                continue
+
+            # from here on, we already know last_message is (> 1d ago) but (< 3d ago)
             try:
-                last_message: discord.Message | None = post.last_message or await post.fetch_message(post.last_message_id)
+                last_message: discord.Message = post.last_message or await post.fetch_message(post.last_message_id)
             except discord.NotFound:
-                # if we can't fetch the message and it's been 3 days
-                # doesn't matter whether the last message is from the post owner or from other users
-                # we will just send this reminder
-                if not check_time_more_than(snowflake_time(post.last_message_id or now_dt).timestamp(), timedelta(days=3)):
+                continue
+            else:
+                # skip if the last message is the message author themselves
+                if last_message.author.id == post_author_id:
                     continue
 
-                time_ago = "3 days"
-            else:
-                # skip if the last message is the message author themselves and
-                # the last message was sent less than 3 days ago
-                if (not check_time_more_than(snowflake_time(last_message.id).timestamp(), timedelta(days=3))) and \
-                   last_message.author.id == post_author_id:
-                    continue
-            
-                time_ago = "24 hours"
-            await post.send(view=CloseNowView(post_author_id, time_ago=time_ago))
+            await post.send(view=CloseNowView(post_author_id, time_ago="24 hours"))
             posts_to_add.append(post.id)
 
         if not posts_to_add:

--- a/SH/cogs/remind.py
+++ b/SH/cogs/remind.py
@@ -127,7 +127,7 @@ class Reminders(commands.Cog):
     async def cog_unload(self):
         self.reminders_loop.cancel()
 
-    @tasks.loop(seconds=30)
+    @tasks.loop(hours=1)
     async def reminders_loop(self):
         """
         This task consists of 3 'loops':

--- a/SH/cogs/remind.py
+++ b/SH/cogs/remind.py
@@ -2,18 +2,18 @@ from __future__ import annotations
 
 import discord
 from discord.ext import commands, tasks
-from functions import add_post_to_pending, \
-    remove_post_from_pending, get_pending_posts, \
-    get_pending_posts_and_timestamps, check_time_more_than_day,\
+from functions import remove_post_from_pending, get_pending_posts, \
+    get_pending_posts_and_timestamps, check_time_more_than,\
     get_post_creator_id, remove_post_from_rtdr, generate_random_id, \
     in_pending_posts, bulk_add_posts_to_pending, bulk_remove_posts_from_pending
 import random
 from discord import ui
-from datetime import datetime, UTC
+from datetime import datetime, timedelta, UTC
 import os
 from dotenv import load_dotenv
 from typing import TYPE_CHECKING
 from discord.utils import snowflake_time, time_snowflake
+
 if TYPE_CHECKING:
     from main import MyClient
 load_dotenv()
@@ -29,11 +29,11 @@ UNANSWERED_TAG_ID = int(os.getenv('UNANSWERED_TAG_ID'))
 APPEAL_GG_TAG_ID = int(os.getenv("APPEAL_GG_TAG_ID"))
 DEVELOPERS_ROLE_ID = int(os.getenv("DEVELOPERS_ROLE_ID"))
 
-reminder_not_sent_posts: dict[int, int] = {} # dictionary of post ids: the amount of tries
 
 class CloseNowRow(ui.ActionRow):
     def __init__(self):
         super().__init__()
+        self.is_owner: bool = False
 
     @ui.button(label="Issue Resolved? Close Post Now", style=discord.ButtonStyle.green, custom_id="remind-close-now")
     async def on_close_now_click(self, interaction: discord.Interaction[MyClient], _: ui.Button):
@@ -59,27 +59,34 @@ class CloseNowRow(ui.ActionRow):
 
 
     @ui.button(label="Cancel", style=discord.ButtonStyle.red, custom_id="remind-cancel")
-    async def on_cancel_click(self, interaction: discord.Interaction, _: ui.Button):
+    async def on_cancel_click(self, interaction: discord.Interaction[MyClient], _: ui.Button):
         text_display: discord.TextDisplay = ui.LayoutView.from_message(interaction.message).find_item(10) # type: ignore
         new_view = discord.ui.LayoutView().add_item(ui.Container(ui.TextDisplay(f"~~{text_display.content}~~"), ui.Separator(), ui.TextDisplay(f"-# Cancelled by {interaction.user}")))
         await interaction.response.edit_message(view=new_view)
         await remove_post_from_pending(interaction.channel_id)
 
+        if self.is_owner:
+            description = "Please send a message here explaining what you still need help with."
+            footer = f"-# When the issue is resolved, you may use </solved:{await interaction.client.get_solved_id()}> to mark it as solved."
+            view = ui.LayoutView().add_item(ui.Container(ui.TextDisplay(description), ui.Separator(), ui.TextDisplay(footer)))
+            await interaction.message.reply(view=view)
+
     async def interaction_check(self, interaction: discord.Interaction[MyClient]) -> bool:
-        is_owner = interaction.user.id == interaction.channel.owner_id or interaction.user.id == await get_post_creator_id(interaction.channel_id)
-        if not (interaction.user.get_role(EXPERTS_ROLE_ID) or interaction.user.get_role(MODERATORS_ROLE_ID) or interaction.user.get_role(DEVELOPERS_ROLE_ID) or is_owner):
+        self.is_owner = interaction.user.id == interaction.channel.owner_id or interaction.user.id == await get_post_creator_id(interaction.channel_id)
+        if not (interaction.user.get_role(EXPERTS_ROLE_ID) or interaction.user.get_role(MODERATORS_ROLE_ID) or interaction.user.get_role(DEVELOPERS_ROLE_ID) or self.is_owner):
             await interaction.response.send_message(content="Only Moderators, Community Experts, Developers and the post creator can use this.", ephemeral=True)
             return False
         return True
 
 
 class CloseNowView(ui.LayoutView):
-    def __init__(self, post_author: int = 0):
+    def __init__(self, post_author: int = 0, *, time_ago: str = "..."):
         super().__init__(timeout=None)
 
         greetings = ("Hi", "Hey", "Hello", "Hi there")
-        textdisplay = ui.TextDisplay(f"{random.choice(greetings)} <@{post_author}>, it seems like your last message was sent more than 24 hours ago.\nIf we don't hear back from you we'll assume the issue is resolved and mark your post as solved.",
-                                          id=10)
+        textdisplay = ui.TextDisplay(
+            f"{random.choice(greetings)} <@{post_author}>, it seems like your last message was sent more than {time_ago} ago.\nIf we don't hear back from you we'll assume the issue is resolved and mark your post as solved.",
+                                    id=10)
         self.confirm_close_buttons = CloseNowRow()
         self.container = ui.Container()
 
@@ -89,12 +96,9 @@ class CloseNowView(ui.LayoutView):
         self.add_item(self.container)
 
 
-class remind(commands.Cog):
+class Reminders(commands.Cog):
     def __init__(self, client: MyClient):
         self.client = client
-        self.check_for_pending_posts.start()
-        self.close_pending_posts.start()
-        self.check_exception_posts.start()
 
     def reminders_filter(self, thread: discord.Thread):
         """  
@@ -117,83 +121,95 @@ class remind(commands.Cog):
     async def add_persistent_view(self):
         self.client.add_view(CloseNowView())
 
+    async def cog_load(self):
+        self.reminders_loop.start()
+
     async def cog_unload(self):
-        self.check_for_pending_posts.cancel()
-        self.close_pending_posts.cancel()
-        self.check_exception_posts.cancel()
+        self.reminders_loop.cancel()
 
     @tasks.loop(hours=1)
-    async def check_exception_posts(self):
-        to_remove = []
-        for post_id, tries in reminder_not_sent_posts.items():
-            post = self.client.get_channel(post_id) or await self.client.fetch_channel(post_id)
-            if tries < 24:
-                try:
-                    message: discord.Message | None = post.last_message or await post.fetch_message(post.last_message_id)
-                except discord.NotFound:
-                    tries+=1
-                    reminder_not_sent_posts[post.id] = tries
-                    continue
-                if check_time_more_than_day(message.created_at.timestamp()):
-                    if post.owner: # make sure the post owner is not None- still in server
-                        greetings = ["Hi", "Hello", "Hey", "Hi there"]
-                        await message.channel.send(content=f"{random.choice(greetings)} {post.owner.mention}, it seems like your last message was sent more than 24 hours ago.\nIf we don't hear back from you we'll assume the issue is resolved and mark your post as solved.", view=CloseNow())
-                        await add_post_to_pending(post_id=post.id)
-                        to_remove.append(post.id)
-                else:
-                    to_remove.append(post.id)
-            elif tries == 24: 
-                try:
-                    message = post.last_message or await post.fetch_message(post.last_message_id)
-                except discord.HTTPException as e:
-                    try:
-                        alerts_thread = post.guild.get_channel_or_thread(ALERTS_THREAD_ID) or await post.guild.fetch_channel(ALERTS_THREAD_ID)
-                    except discord.NotFound as e2:
-                        raise ExceptionGroup('Tried to fetch message and Alerts Thread', [e, e2])
-                    await alerts_thread.send(
-                        content=f"Reminder message could not be sent to {post.mention}.\nError: `{e.text}` Error code: `{e.code}` Status: `{e.status}`"
-                    )
-                    reminder_not_sent_posts[post.id] += 1
-                    continue
-                if check_time_more_than_day(message.created_at.timestamp()):
-                    await add_post_to_pending(post.id)
-                else:
-                    to_remove.append(post.id)
-        for post_id in to_remove:
-            reminder_not_sent_posts.pop(post_id)
+    async def reminders_loop(self):
+        """
+        This task consists of 3 'loops':
+        - close_abandoned_posts
+        - check_for_pending_posts
+        - close_pending_posts
+        """
+        await self.close_pending_posts()
+        support_channel = self.client.get_channel(SUPPORT_CHANNEL_ID)
+        if not support_channel:
+            return
 
-    @tasks.loop(hours=1)
-    async def check_for_pending_posts(self):
+        posts = await support_channel.guild.active_threads()
+        if posts:
+            await self.close_abandoned_posts(posts)
+            await self.check_for_pending_posts(posts)
+
+    async def close_abandoned_posts(self, posts: list[discord.Thread]):
         support = self.client.get_channel(SUPPORT_CHANNEL_ID)
         if not support:
             return
 
+        for i in range(len(posts) - 1, -1, -1): # we need to do this so that we don't modify the rest of the list when we remove a post
+            post = posts[i]
+            if post.parent_id != SUPPORT_CHANNEL_ID or post.locked or NEED_DEV_REVIEW_TAG_ID in post._applied_tags:
+                continue
+            
+            if SOLVED_TAG_ID in post._applied_tags: # /solved could've been used as the post doesn't get archived immediately
+                del posts[i]
+                continue
+
+            owner = post.guild.get_member(await get_post_creator_id(post.id)) or post.owner
+            if owner is not None: # post owner/creator will be None if they left the server
+                continue
+
+            tags = [support.get_tag(SOLVED_TAG_ID)]
+            cb = support.get_tag(CUSTOM_BRANDING_TAG_ID)
+            appeal = support.get_tag(APPEAL_GG_TAG_ID)
+            if CUSTOM_BRANDING_TAG_ID in post._applied_tags: 
+                tags.append(cb)
+            if APPEAL_GG_TAG_ID in post._applied_tags:
+                tags.append(appeal)
+            action_id = generate_random_id()
+            await post.send("This post was automatically marked as **Solved** because the post creator left the server.")
+            await post.edit(archived=True, reason=f"ID: {action_id}. Post creator left the server, auto close post", applied_tags=tags)
+            await self.client.send_log(ALERTS_THREAD_ID, action_id=action_id, post_mention=post.mention, tags=tags, context="Post creator left the server")
+            del posts[i] # remove from the post so that check_for_pending_posts won't need to check for it
+
+
+    async def check_for_pending_posts(self, posts: list[discord.Thread]):
         posts_to_add: list[int] = []
         pending_posts: list[int] = await get_pending_posts() # Cache the list to avoid DB calls every iteration of the loop
-        for post in await support.guild.active_threads():
+        for post in posts:
             now_dt = time_snowflake(datetime.now(UTC))
-            more_than_day = check_time_more_than_day(snowflake_time(post.last_message_id or now_dt).timestamp()) # Check time before making any further API/DB calls
-            if not more_than_day or post.id in reminder_not_sent_posts or post.id in pending_posts:
+            more_than_day = check_time_more_than(snowflake_time(post.last_message_id or now_dt).timestamp(),
+                                                timedelta(days=1)) # Check time before making any further API/DB calls
+            if not more_than_day or post.id in pending_posts:
                 continue
             if not self.reminders_filter(post):
                 continue
-            try:
-                message: discord.Message | None = post.last_message or await post.fetch_message(post.last_message_id)
-            except discord.NotFound: # message id could be for a message that was already deleted
-                reminder_not_sent_posts[post.id] = 1
-                continue
-            except discord.HTTPException as e:
-                try:
-                    alerts = post.guild.get_channel_or_thread(ALERTS_THREAD_ID) or await post.guild.fetch_channel(ALERTS_THREAD_ID)
-                except discord.NotFound as e2:
-                    raise ExceptionGroup('Tried to fetch message and Alerts Thread', [e, e2])
-                await alerts.send(content=f"Reminder message could not be sent to {post.mention}.\nError: `{e.text}` Error code: `{e.code}` Status: {e.status}")
-                continue
+
             post_author_id = await get_post_creator_id(post.id) or post.owner_id
-            author_not_owner = message.author.id != post_author_id
-            if author_not_owner and message.author != self.client.user and post.owner:
-                await message.channel.send(view=CloseNowView(post_author_id))
-                posts_to_add.append(post.id)
+            try:
+                last_message: discord.Message | None = post.last_message or await post.fetch_message(post.last_message_id)
+            except discord.NotFound:
+                # if we can't fetch the message and it's been 3 days
+                # doesn't matter whether the last message is from the post owner or from other users
+                # we will just send this reminder
+                if not check_time_more_than(snowflake_time(post.last_message_id or now_dt).timestamp(), timedelta(days=3)):
+                    continue
+
+                time_ago = "3 days"
+            else:
+                # skip if the last message is the message author themselves and
+                # the last message was sent less than 3 days ago
+                if (not check_time_more_than(snowflake_time(last_message.id).timestamp(), timedelta(days=3))) and \
+                   last_message.author.id == post_author_id:
+                    continue
+            
+                time_ago = "24 hours"
+            await post.send(view=CloseNowView(post_author_id, time_ago=time_ago))
+            posts_to_add.append(post.id)
 
         if not posts_to_add:
             return
@@ -211,23 +227,24 @@ class remind(commands.Cog):
             if message_author and others_filter and await in_pending_posts(message.channel.id):
                 await remove_post_from_pending(message.channel.id)
 
-    @tasks.loop(hours=1)
+
     async def close_pending_posts(self):
         posts_to_remove: list[int] = []
         pending_posts = await get_pending_posts_and_timestamps()
 
         for post_id, timestamp in pending_posts:
+            # only close posts that have been pending for > 1 day
+            if not check_time_more_than(timestamp, timedelta(days=1)):
+                continue
+
             try:
                 post = self.client.get_channel(post_id) or await self.client.fetch_channel(post_id)
             except discord.NotFound:
-                continue
-
-            if not post: # check if the post was successfully fetched (not None)
+                await remove_post_from_rtdr(post.id)
                 posts_to_remove.append(post_id)
                 continue
 
-            ndr = NEED_DEV_REVIEW_TAG_ID not in post._applied_tags
-            if ndr and check_time_more_than_day(timestamp):
+            if NEED_DEV_REVIEW_TAG_ID not in post._applied_tags:
                 applied_tags = post.applied_tags
                 tags = [post.parent.get_tag(SOLVED_TAG_ID)]
                 cb = post.parent.get_tag(CUSTOM_BRANDING_TAG_ID)
@@ -238,10 +255,13 @@ class remind(commands.Cog):
                     tags.append(appeal)
                 action_id = generate_random_id()
                 try:
-                    await post.edit(archived=True, reason=f"ID: {action_id}. Post inactive for 2 days", applied_tags=tags) # make the post archived and add the tags
+                    await post.edit(archived=True, 
+                                    reason=f"ID: {action_id}. Post inactive for too long.", 
+                                    applied_tags=tags) # type: ignore
                 except discord.HTTPException:
                     continue
-                await self.client.send_log(ALERTS_THREAD_ID, action_id=action_id, post_mention=post.mention, tags=tags, context="Close pending post")
+                await self.client.send_log(ALERTS_THREAD_ID, action_id=action_id, post_mention=post.mention, tags=tags, 
+                                           context=f"Close pending post")
                 await remove_post_from_rtdr(post.id)
                 posts_to_remove.append(post.id)
 
@@ -250,30 +270,14 @@ class remind(commands.Cog):
         await bulk_remove_posts_from_pending(posts_to_remove)
 
 
-    @check_for_pending_posts.before_loop
-    async def cfpp_before_loop(self):
+    @reminders_loop.before_loop
+    async def reminders_loop_before_loop(self):
         await self.client.wait_until_ready() # only start the loop when the bot's cache is ready
 
-    @close_pending_posts.before_loop
-    async def cpp_before_loop(self):
-        await self.client.wait_until_ready()
-    
-    @check_exception_posts.before_loop
-    async def cep_before_loop(self):
-        await self.client.wait_until_ready()
+    @reminders_loop.error
+    async def reminders_loop_error(self, error: BaseException):
+        await self.client.send_unhandled_error(error, task=self.reminders_loop)
 
-
-    @check_for_pending_posts.error
-    async def cfpp_error(self, error: BaseException):
-        await self.client.send_unhandled_error(error, task=self.check_for_pending_posts)
-
-    @close_pending_posts.error
-    async def cpp_error(self, error: BaseException):
-        await self.client.send_unhandled_error(error, task=self.close_pending_posts)
-    
-    @check_exception_posts.error
-    async def cep_error(self, error: BaseException):
-        await self.client.send_unhandled_error(error, task=self.check_exception_posts)
 
 async def setup(client: MyClient):
-    await client.add_cog(remind(client))
+    await client.add_cog(Reminders(client))

--- a/SH/cogs/utility.py
+++ b/SH/cogs/utility.py
@@ -298,8 +298,8 @@ class utility(commands.Cog):
                 await interaction.response.send_message("Post successfully unsolved!")
             else:
                 title = "### Post Successfully Unsolved"
-                description = "Please send a message here explaining what you still need help with"
-                footer = f"-# If the issue is resolved, you may use </solved:{await self.client.get_solved_id()}> to mark it as solved."
+                description = "Please send a message here explaining what you still need help with."
+                footer = f"-# When the issue is resolved, you may use </solved:{await self.client.get_solved_id()}> to mark it as solved."
                 view = ui.LayoutView().add_item(ui.Container(ui.TextDisplay(title), ui.Separator(visible=False), 
                                                              ui.TextDisplay(description), ui.Separator(), ui.TextDisplay(footer)))
                 await interaction.response.send_message(view=view)

--- a/SH/functions.py
+++ b/SH/functions.py
@@ -37,12 +37,13 @@ def generate_random_id() -> str:
     characters = ascii_letters + digits
     return ''.join(random.choice(characters) for _ in range(6))
 
-def check_time_more_than_day(timestamp: float) -> bool:
+def check_time_more_than(timestamp: float, to_compare: datetime.timedelta) -> bool:
     """  
-    Check if the given time is more than a day ago
+    Check if the given timestamp is more than to_compare
     """
-    one_day_ago = datetime.datetime.now(datetime.UTC) - datetime.timedelta(days=1)
-    return datetime.datetime.fromtimestamp(timestamp, datetime.UTC) < one_day_ago
+    timestamp_dt = datetime.datetime.fromtimestamp(timestamp, datetime.UTC)
+
+    return timestamp_dt + to_compare <  datetime.datetime.now(datetime.UTC)
 
 def format_list(items: Sequence, conjunction: str = "or") -> str:
     return ", ".join(items[:-1]) + f" {conjunction} " + items[-1]

--- a/SH/test_functions.py
+++ b/SH/test_functions.py
@@ -1,20 +1,20 @@
 import unittest
-from functions import check_time_more_than_day
+from functions import check_time_more_than
 from datetime import datetime, timedelta, UTC
 
 class TestDatetime(unittest.TestCase):
 
     def test_less_than_day(self):
         time_object = datetime.now(UTC) - timedelta(hours=5)
-        self.assertFalse(check_time_more_than_day(time_object.timestamp()))
+        self.assertFalse(check_time_more_than(time_object.timestamp(), timedelta(days=1)))
     
     def test_more_than_day(self):
         time_object = datetime.now(UTC) - timedelta(days=2)
-        self.assertTrue(check_time_more_than_day(time_object.timestamp()))
+        self.assertTrue(check_time_more_than(time_object.timestamp(), timedelta(days=1)))
 
     def test_future_time(self):
         time_object = datetime.now(UTC) + timedelta(hours=25)
-        self.assertFalse(check_time_more_than_day(time_object.timestamp()))
+        self.assertFalse(check_time_more_than(time_object.timestamp(), timedelta(days=1)))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## What does this PR do?
Combines all reminders loop + close_abandoned post into one tasks.loop, and simplify code.
This naturally improves performance too.

### Change in behaviour
- Instead of adding to exception post because the last message can't be fetched, SH will now send the reminder if the last message > 3d ago, even if the last message was from the author.

This should hopefully fix any posts not being cleaned up by reminders.


- issue: <!-- Please include the issue number this PR is addressing like so: "- issue: #12". If there isn't an issue, please create one!-->asdf #73 #58 

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
- [ ] This PR is not a code change (i.e, README)
