### PR TITLE
Removing Members Intent

### DIFF
--- a/SH/cogs/autoadd.py
+++ b/SH/cogs/autoadd.py
@@ -124,7 +124,7 @@ class autoadd(commands.Cog):
         if (
             content_len + len(thread.name) < 25
             or start_msg.content.casefold() == thread.name.casefold()
-            and not thread.owner.bot # prevent the message from sending if it was sent via rtdr
+            and thread.owner_id != self.client.user.id # prevent the message from sending if it was sent via rtdr
         ):
             view = ui.LayoutView()
             container = ui.Container()
@@ -137,7 +137,7 @@ class autoadd(commands.Cog):
             self.client.incomplete_msg_posts.add(thread.id)
 
     async def send_suggestion_message(self, message: discord.Message):
-        if message.author == self.client.user or (message.author != message.channel.owner and message.author.id != await get_post_creator_id(message.channel.id)):
+        if message.author.id == self.client.user.id or (message.author.id != message.channel.owner_id and message.author.id != await get_post_creator_id(message.channel.id)):
             return
         tags = message.channel._applied_tags
         if SOLVED_TAG_ID not in tags and NEED_DEV_REVIEW_TAG_ID not in tags and message.id != message.channel.id: # if the message id == message channel id it means that its a starter message of a thread.
@@ -148,12 +148,11 @@ class autoadd(commands.Cog):
                 self.sent_post_ids.append(message.channel.id)
 
     async def replace_unanswered_tag(self, message: discord.Message):
-        if UNANSWERED_TAG_ID not in message.channel._applied_tags or message.author == self.client.user:
+        if UNANSWERED_TAG_ID not in message.channel._applied_tags or message.author.id == self.client.user.id:
             return
         applied_tags = message.channel.applied_tags
         owner_id = await get_post_creator_id(message.channel.id) or message.channel.owner_id
-        author_not_owner = message.author.id != owner_id
-        if author_not_owner:
+        if message.author.id != owner_id:
             tags = [message.channel.parent.get_tag(NOT_SOLVED_TAG_ID)]
             cb = message.channel.parent.get_tag(CUSTOM_BRANDING_TAG_ID)
             appeal = message.channel.parent.get_tag(APPEAL_GG_TAG_ID)

--- a/SH/cogs/bot.py
+++ b/SH/cogs/bot.py
@@ -21,7 +21,7 @@ MODERATORS_ROLE_ID = int(os.getenv("MODERATORS_ROLE_ID"))
 ALERTS_THREAD_ID = int(os.getenv('ALERTS_THREAD_ID'))
 DEVELOPERS_ROLE_ID = int(os.getenv("DEVELOPERS_ROLE_ID"))
 
-class bot(commands.Cog):
+class Bot(commands.Cog):
     def __init__(self, client: MyClient):
         self.client = client
         self.last_restarted = time.time()
@@ -84,4 +84,4 @@ class bot(commands.Cog):
         await ctx.reply(view=view, mention_author=False)
 
 async def setup(client: MyClient):
-    await client.add_cog(bot(client))
+    await client.add_cog(Bot(client))

--- a/SH/cogs/epi.py
+++ b/SH/cogs/epi.py
@@ -570,7 +570,7 @@ class epi(commands.Cog):
         # set the webhook ID and token (if needed)
         await self.set_webhook_page(followup.channel)
 
-        xge = self.client.get_user(XGE_USER_ID) or await self.client.fetch_user(XGE_USER_ID) 
+        xge = await self.client.fetch_user(XGE_USER_ID) 
         async with aiohttp.ClientSession(trust_env=True) as session:
             data = {
                 "topic": NTFY_TOPIC_NAME,

--- a/SH/cogs/remind.py
+++ b/SH/cogs/remind.py
@@ -12,6 +12,7 @@ from discord import ui
 from discord import app_commands
 from datetime import timedelta
 import os
+from time import perf_counter
 from dotenv import load_dotenv
 from typing import TYPE_CHECKING
 from discord.utils import snowflake_time
@@ -180,28 +181,49 @@ class Reminders(commands.Cog):
 
         await self.client.send_log(ALERTS_THREAD_ID, content="\n".join(log_end_content))
 
+    async def filter_and_get_owner_ids(self, posts: list[discord.Thread]) -> list[int]:
+        """
+        Remove posts that are:
+            - Not from support
+            - Locked
+            - Have solved or NDR tag
+
+        Finally, it returns a list of owner ids
+        """
+        user_ids: list[int] = []
+        for i in range(len(posts) - 1, -1, -1): # we need to do this so that we don't modify the rest of the list when we remove a post
+            post = posts[i]
+            if post.parent_id != SUPPORT_CHANNEL_ID or post.locked or any(tag_id in post._applied_tags for tag_id in (SOLVED_TAG_ID, NEED_DEV_REVIEW_TAG_ID)):
+                del posts[i]
+                continue
+
+            owner_id = post.owner_id if post.owner_id != self.client.user.id else await get_post_creator_id(post.id)
+            if owner_id is not None:
+                user_ids.append(owner_id)
+        return user_ids
+
     async def close_abandoned_posts(self, posts: list[discord.Thread]):
         support = self.client.get_channel(SUPPORT_CHANNEL_ID)
         if not support:
             return
+        start = perf_counter()
+        owner_ids = await self.filter_and_get_owner_ids(posts)
+        if not owner_ids:
+            return
+        # owner ids of which are still in the server
+        valid_owner_ids = {m.id for m in await support.guild.query_members(user_ids=owner_ids)}
 
         for i in range(len(posts) - 1, -1, -1): # we need to do this so that we don't modify the rest of the list when we remove a post
             post = posts[i]
-            if post.parent_id != SUPPORT_CHANNEL_ID or post.locked or NEED_DEV_REVIEW_TAG_ID in post._applied_tags:
-                continue
-            
-            if SOLVED_TAG_ID in post._applied_tags: # /solved could've been used as the post doesn't get archived immediately
-                del posts[i]
-                continue
 
-            owner = post.guild.get_member(await get_post_creator_id(post.id)) or post.owner
-            if owner is not None: # post owner/creator will be None if they left the server
+            owner_id = post.owner_id if post.owner_id != self.client.user.id else await get_post_creator_id(post.id)
+            if owner_id in valid_owner_ids:
                 continue
 
             tags = [support.get_tag(SOLVED_TAG_ID)]
             cb = support.get_tag(CUSTOM_BRANDING_TAG_ID)
             appeal = support.get_tag(APPEAL_GG_TAG_ID)
-            if CUSTOM_BRANDING_TAG_ID in post._applied_tags: 
+            if CUSTOM_BRANDING_TAG_ID in post._applied_tags:
                 tags.append(cb)
             if APPEAL_GG_TAG_ID in post._applied_tags:
                 tags.append(appeal)
@@ -210,7 +232,7 @@ class Reminders(commands.Cog):
             await post.edit(archived=True, reason=f"ID: {action_id}. Post creator left the server, auto close post", applied_tags=tags)
             await self.client.send_log(ALERTS_THREAD_ID, action_id=action_id, post_mention=post.mention, tags=tags, context="Post creator left the server")
             del posts[i] # remove from the post so that check_for_pending_posts won't need to check for it
-
+        print(f"Took: {perf_counter() - start:.5f}")
 
     async def check_for_pending_posts(self, posts: list[discord.Thread]):
         posts_to_add: list[int] = []
@@ -254,7 +276,7 @@ class Reminders(commands.Cog):
             
     @commands.Cog.listener('on_message')
     async def remove_pending_posts(self, message: discord.Message):
-        if message.author == self.client.user:
+        if message.author.id == self.client.user.id:
             return
         
         if isinstance(message.channel, discord.Thread) and message.channel.parent_id == SUPPORT_CHANNEL_ID:

--- a/SH/cogs/remind.py
+++ b/SH/cogs/remind.py
@@ -12,7 +12,6 @@ from discord import ui
 from discord import app_commands
 from datetime import timedelta
 import os
-from time import perf_counter
 from dotenv import load_dotenv
 from typing import TYPE_CHECKING
 from discord.utils import snowflake_time
@@ -206,7 +205,7 @@ class Reminders(commands.Cog):
         support = self.client.get_channel(SUPPORT_CHANNEL_ID)
         if not support:
             return
-        start = perf_counter()
+
         owner_ids = await self.filter_and_get_owner_ids(posts)
         if not owner_ids:
             return
@@ -232,7 +231,6 @@ class Reminders(commands.Cog):
             await post.edit(archived=True, reason=f"ID: {action_id}. Post creator left the server, auto close post", applied_tags=tags)
             await self.client.send_log(ALERTS_THREAD_ID, action_id=action_id, post_mention=post.mention, tags=tags, context="Post creator left the server")
             del posts[i] # remove from the post so that check_for_pending_posts won't need to check for it
-        print(f"Took: {perf_counter() - start:.5f}")
 
     async def check_for_pending_posts(self, posts: list[discord.Thread]):
         posts_to_add: list[int] = []

--- a/SH/cogs/waiting_for_reply.py
+++ b/SH/cogs/waiting_for_reply.py
@@ -40,13 +40,13 @@ class waiting_for_reply(commands.Cog):
     @commands.Cog.listener('on_message')
     async def add_remove_waiting_for_reply(self, message: discord.Message):
         channel_id = message.channel.id
-        if message.author == self.client.user or not isinstance(message.channel, discord.Thread) or message.channel.parent_id != SUPPORT_CHANNEL_ID:
+        if message.author.id == self.client.user.id or not isinstance(message.channel, discord.Thread) or message.channel.parent_id != SUPPORT_CHANNEL_ID:
             return
 
         support = message.channel.parent
         wfr = support.get_tag(WAITING_FOR_REPLY_TAG_ID)
         applied_tags = message.channel._applied_tags
-        message_author_is_owner = message.author == message.channel.owner or message.author.id == await get_post_creator_id(message.channel.id)
+        message_author_is_owner = message.author.id == message.channel.owner_id or message.author.id == await get_post_creator_id(message.channel.id)
         has_wfr = WAITING_FOR_REPLY_TAG_ID in applied_tags
         if message.id == message.channel.id or NEED_DEV_REVIEW_TAG_ID in applied_tags or UNANSWERED_TAG_ID in applied_tags or SOLVED_TAG_ID in applied_tags:
             return

--- a/SH/main.py
+++ b/SH/main.py
@@ -21,7 +21,6 @@ class MyClient(commands.Bot):
         intents.message_content = True
         intents.guild_messages = True
         intents.guilds = True
-        intents.members = False
         intents.guild_reactions = True
         super().__init__(PREFIX, help_command=None, intents=intents, strip_after_prefix=True, 
                         allowed_contexts=app_commands.AppCommandContext(guild=True),

--- a/SH/main.py
+++ b/SH/main.py
@@ -21,7 +21,7 @@ class MyClient(commands.Bot):
         intents.message_content = True
         intents.guild_messages = True
         intents.guilds = True
-        intents.members = True
+        intents.members = False
         intents.guild_reactions = True
         super().__init__(PREFIX, help_command=None, intents=intents, strip_after_prefix=True, 
                         allowed_contexts=app_commands.AppCommandContext(guild=True),


### PR DESCRIPTION
## What does this PR do?
This PR removes the `members` intent and updates any sort of code that relies it.
This is mainly done through:
- Using `owner_id` instead of `owner`
- **Reminders**
  - First we loop through the active posts and get all the owner ids
  - Next, we call `guild.query_members(user_ids=owner_ids)`. This returns a list of member objects for those owner_ids which are still in the server
  - Then, we loop through the posts again and find posts who's owner_id was not returned in `query_members` and close the post.

Interactions and Message objects auto populate `Member` objects, so we don't have to worry about those.

**Reviews are much appreciated!**
- issue: <!-- Please include the issue number this PR is addressing like so: "- issue: #12". If there isn't an issue, please create one!--> #84 

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
- [ ] This PR is not a code change (i.e, README)
