### PR TITLE
Fix: RTDR ower_id being cleared

### DIFF
--- a/SH/cogs/autoadd.py
+++ b/SH/cogs/autoadd.py
@@ -70,7 +70,7 @@ class ConfirmCloseButtons(ui.ActionRow):
             await interaction.message.reply(view=view)
 
     async def interaction_check(self, interaction: discord.Interaction[SHBot]) -> bool:
-        self.is_owner = interaction.user.id == await interaction.client.get_owner_id(interaction.channel)
+        self.is_owner = interaction.user.id == await interaction.client.get_post_owner_id(interaction.channel)
         if not (self.is_owner or interaction.user.get_role(EXPERTS_ROLE_ID) or interaction.user.get_role(MODERATORS_ROLE_ID) or interaction.user.get_role(DEVELOPERS_ROLE_ID)):
             await interaction.response.send_message(content=f"Only <@&{EXPERTS_ROLE_ID}>, <@&{MODERATORS_ROLE_ID}>, <@&{DEVELOPERS_ROLE_ID}> and the post creator can use this!", ephemeral=True)
             return False
@@ -137,7 +137,7 @@ class AutoAdd(commands.Cog):
             self.bot.incomplete_msg_posts.add(thread.id)
 
     async def send_suggestion_message(self, message: discord.Message):
-        if message.author.id == self.bot.user.id or message.author.id != await self.bot.get_owner_id(message.channel):
+        if message.author.id == self.bot.user.id or message.author.id != await self.bot.get_post_owner_id(message.channel):
             return
         tags = message.channel._applied_tags
         if SOLVED_TAG_ID not in tags and NEED_DEV_REVIEW_TAG_ID not in tags and message.id != message.channel.id: # if the message id == message channel id it means that its a starter message of a thread.
@@ -151,7 +151,7 @@ class AutoAdd(commands.Cog):
         if UNANSWERED_TAG_ID not in message.channel._applied_tags or message.author.id == self.bot.user.id:
             return
         applied_tags = message.channel.applied_tags
-        owner_id = await self.bot.get_owner_id(message.channel)
+        owner_id = await self.bot.get_post_owner_id(message.channel)
         if message.author.id != owner_id:
             tags = [message.channel.parent.get_tag(NOT_SOLVED_TAG_ID)]
             cb = message.channel.parent.get_tag(CUSTOM_BRANDING_TAG_ID)
@@ -174,7 +174,7 @@ class AutoAdd(commands.Cog):
             tag_filters = NEED_DEV_REVIEW_TAG_ID not in tags and SOLVED_TAG_ID not in tags
             other_filters = not message_channel.locked and not message_channel.archived
             if tag_filters and other_filters:
-                owner_id = await self.bot.get_owner_id(message_channel)
+                owner_id = await self.bot.get_post_owner_id(message_channel)
                 await message_channel.send(
                     view=ConfirmCloseView(post_author=owner_id)
                 )

--- a/SH/cogs/autoadd.py
+++ b/SH/cogs/autoadd.py
@@ -6,7 +6,7 @@ import re
 import random
 import os
 from dotenv import load_dotenv
-from functions import get_post_creator_id, generate_random_id, remove_post_from_rtdr
+from functions import generate_random_id, remove_post_from_rtdr
 from discord import ui
 from typing import TYPE_CHECKING
 if TYPE_CHECKING:
@@ -70,7 +70,7 @@ class ConfirmCloseButtons(ui.ActionRow):
             await interaction.message.reply(view=view)
 
     async def interaction_check(self, interaction: discord.Interaction[SHBot]) -> bool:
-        self.is_owner = interaction.user.id == interaction.channel.owner_id or interaction.user.id == await get_post_creator_id(interaction.channel_id)
+        self.is_owner = interaction.user.id == await interaction.client.get_owner_id(interaction.channel)
         if not (self.is_owner or interaction.user.get_role(EXPERTS_ROLE_ID) or interaction.user.get_role(MODERATORS_ROLE_ID) or interaction.user.get_role(DEVELOPERS_ROLE_ID)):
             await interaction.response.send_message(content=f"Only <@&{EXPERTS_ROLE_ID}>, <@&{MODERATORS_ROLE_ID}>, <@&{DEVELOPERS_ROLE_ID}> and the post creator can use this!", ephemeral=True)
             return False
@@ -137,7 +137,7 @@ class AutoAdd(commands.Cog):
             self.bot.incomplete_msg_posts.add(thread.id)
 
     async def send_suggestion_message(self, message: discord.Message):
-        if message.author.id == self.bot.user.id or (message.author.id != message.channel.owner_id and message.author.id != await get_post_creator_id(message.channel.id)):
+        if message.author.id == self.bot.user.id or message.author.id != await self.bot.get_owner_id(message.channel):
             return
         tags = message.channel._applied_tags
         if SOLVED_TAG_ID not in tags and NEED_DEV_REVIEW_TAG_ID not in tags and message.id != message.channel.id: # if the message id == message channel id it means that its a starter message of a thread.
@@ -151,7 +151,7 @@ class AutoAdd(commands.Cog):
         if UNANSWERED_TAG_ID not in message.channel._applied_tags or message.author.id == self.bot.user.id:
             return
         applied_tags = message.channel.applied_tags
-        owner_id = await get_post_creator_id(message.channel.id) or message.channel.owner_id
+        owner_id = await self.bot.get_owner_id(message.channel)
         if message.author.id != owner_id:
             tags = [message.channel.parent.get_tag(NOT_SOLVED_TAG_ID)]
             cb = message.channel.parent.get_tag(CUSTOM_BRANDING_TAG_ID)
@@ -167,15 +167,14 @@ class AutoAdd(commands.Cog):
     @commands.Cog.listener('on_raw_message_delete')
     async def suggest_closing_post(self, payload: discord.RawMessageDeleteEvent):
         message_channel = self.bot.get_channel(payload.channel_id)
-        is_in_support = isinstance(message_channel, discord.Thread) \
-                    and message_channel.parent_id == SUPPORT_CHANNEL_ID
+        is_in_support = isinstance(message_channel, discord.Thread) and message_channel.parent_id == SUPPORT_CHANNEL_ID
         is_starter_message = payload.message_id == payload.channel_id
         if is_in_support and is_starter_message:
             tags = message_channel._applied_tags
             tag_filters = NEED_DEV_REVIEW_TAG_ID not in tags and SOLVED_TAG_ID not in tags
             other_filters = not message_channel.locked and not message_channel.archived
             if tag_filters and other_filters:
-                owner_id = await get_post_creator_id(payload.channel_id) or message_channel.owner_id
+                owner_id = await self.bot.get_owner_id(message_channel)
                 await message_channel.send(
                     view=ConfirmCloseView(post_author=owner_id)
                 )

--- a/SH/cogs/debug.py
+++ b/SH/cogs/debug.py
@@ -103,7 +103,7 @@ class DebugCog(commands.Cog):
         else:
             pending_post_timestamp = 0
         
-        owner_id = await functions.get_post_creator_id(post.id) or post.owner_id
+        owner_id = await self.bot.get_owner_id(post)
         await interaction.followup.send(view=DebugPostView(post, is_pending=is_pending, pending_post_timestamp=pending_post_timestamp,
                                                            owner_id=owner_id),
                                                            allowed_mentions=discord.AllowedMentions.none())

--- a/SH/cogs/debug.py
+++ b/SH/cogs/debug.py
@@ -103,7 +103,7 @@ class DebugCog(commands.Cog):
         else:
             pending_post_timestamp = 0
         
-        owner_id = await self.bot.get_owner_id(post)
+        owner_id = await self.bot.get_post_owner_id(post)
         await interaction.followup.send(view=DebugPostView(post, is_pending=is_pending, pending_post_timestamp=pending_post_timestamp,
                                                            owner_id=owner_id),
                                                            allowed_mentions=discord.AllowedMentions.none())

--- a/SH/cogs/readthedamnrules.py
+++ b/SH/cogs/readthedamnrules.py
@@ -116,7 +116,7 @@ class RTDR(commands.Cog):
         view.add_item(container)
 
         post = await support.create_thread(
-            name=title,
+            name=f"{title[0:75]} ({reference_message.author.id})", # (USER_ID) adds about 20-24 chars, max is 100 chars
             view=view,
             files=files
         )

--- a/SH/cogs/remind.py
+++ b/SH/cogs/remind.py
@@ -77,7 +77,7 @@ class CloseNowRow(ui.ActionRow):
             await interaction.message.reply(view=view)
 
     async def interaction_check(self, interaction: discord.Interaction[SHBot]) -> bool:
-        self.is_owner = interaction.user.id == await interaction.client.get_owner_id(interaction.channel)
+        self.is_owner = interaction.user.id == await interaction.client.get_post_owner_id(interaction.channel)
         if not (interaction.user.get_role(EXPERTS_ROLE_ID) or interaction.user.get_role(MODERATORS_ROLE_ID) or interaction.user.get_role(DEVELOPERS_ROLE_ID) or self.is_owner):
             await interaction.response.send_message(content="Only Moderators, Community Experts, Developers and the post creator can use this.", ephemeral=True)
             return False
@@ -180,7 +180,7 @@ class Reminders(commands.Cog):
 
         await self.bot.send_log(ALERTS_THREAD_ID, content="\n".join(log_end_content))
 
-    async def filter_and_get_owner_ids(self, posts: list[discord.Thread]) -> list[int]:
+    async def filter_and_get_post_owner_ids(self, posts: list[discord.Thread]) -> list[int]:
         """
         Remove posts that are:
             - Not from support
@@ -196,7 +196,7 @@ class Reminders(commands.Cog):
                 del posts[i]
                 continue
 
-            owner_id = await self.bot.get_owner_id(post)
+            owner_id = await self.bot.get_post_owner_id(post)
             if owner_id is not None:
                 user_ids.append(owner_id)
         return user_ids
@@ -206,7 +206,7 @@ class Reminders(commands.Cog):
         if not support:
             return
 
-        owner_ids = await self.filter_and_get_owner_ids(posts)
+        owner_ids = await self.filter_and_get_post_owner_ids(posts)
         if not owner_ids:
             return
         # owner ids of which are still in the server
@@ -215,7 +215,7 @@ class Reminders(commands.Cog):
         for i in range(len(posts) - 1, -1, -1): # we need to do this so that we don't modify the rest of the list when we remove a post
             post = posts[i]
 
-            owner_id = await self.bot.get_owner_id(post)
+            owner_id = await self.bot.get_post_owner_id(post)
             if owner_id in valid_owner_ids:
                 continue
 
@@ -247,7 +247,7 @@ class Reminders(commands.Cog):
             if not self.reminders_filter(post):
                 continue
 
-            post_author_id = await self.bot.get_owner_id(post)
+            post_author_id = await self.bot.get_post_owner_id(post)
             
             # If the last message > 3d, we send the reminder regardless of other requirements
             if check_time_more_than(last_msg_timestamp, timedelta(days=3)):
@@ -279,7 +279,7 @@ class Reminders(commands.Cog):
         
         if isinstance(message.channel, discord.Thread) and message.channel.parent_id == SUPPORT_CHANNEL_ID:
             others_filter = not message.channel.locked and NEED_DEV_REVIEW_TAG_ID not in message.channel._applied_tags
-            owner_id = await self.bot.get_owner_id(message.channel)
+            owner_id = await self.bot.get_post_owner_id(message.channel)
             message_author = message.author.id == owner_id
             if message_author and others_filter and await in_pending_posts(message.channel.id):
                 await remove_post_from_pending(message.channel.id)

--- a/SH/cogs/remind.py
+++ b/SH/cogs/remind.py
@@ -4,7 +4,7 @@ import discord
 from discord.ext import commands, tasks
 from functions import remove_post_from_pending, get_pending_posts, \
     get_pending_posts_and_timestamps, check_time_more_than,\
-    get_post_creator_id, remove_post_from_rtdr, generate_random_id, \
+    remove_post_from_rtdr, generate_random_id, \
     in_pending_posts, bulk_add_posts_to_pending, bulk_remove_posts_from_pending
 import random
 import asyncio
@@ -77,7 +77,7 @@ class CloseNowRow(ui.ActionRow):
             await interaction.message.reply(view=view)
 
     async def interaction_check(self, interaction: discord.Interaction[SHBot]) -> bool:
-        self.is_owner = interaction.user.id == interaction.channel.owner_id or interaction.user.id == await get_post_creator_id(interaction.channel_id)
+        self.is_owner = interaction.user.id == await interaction.client.get_owner_id(interaction.channel)
         if not (interaction.user.get_role(EXPERTS_ROLE_ID) or interaction.user.get_role(MODERATORS_ROLE_ID) or interaction.user.get_role(DEVELOPERS_ROLE_ID) or self.is_owner):
             await interaction.response.send_message(content="Only Moderators, Community Experts, Developers and the post creator can use this.", ephemeral=True)
             return False
@@ -196,7 +196,7 @@ class Reminders(commands.Cog):
                 del posts[i]
                 continue
 
-            owner_id = post.owner_id if post.owner_id != self.bot.user.id else await get_post_creator_id(post.id)
+            owner_id = await self.bot.get_owner_id(post)
             if owner_id is not None:
                 user_ids.append(owner_id)
         return user_ids
@@ -215,7 +215,7 @@ class Reminders(commands.Cog):
         for i in range(len(posts) - 1, -1, -1): # we need to do this so that we don't modify the rest of the list when we remove a post
             post = posts[i]
 
-            owner_id = post.owner_id if post.owner_id != self.bot.user.id else await get_post_creator_id(post.id)
+            owner_id = await self.bot.get_owner_id(post)
             if owner_id in valid_owner_ids:
                 continue
 
@@ -247,7 +247,7 @@ class Reminders(commands.Cog):
             if not self.reminders_filter(post):
                 continue
 
-            post_author_id = await get_post_creator_id(post.id) or post.owner_id
+            post_author_id = await self.bot.get_owner_id(post)
             
             # If the last message > 3d, we send the reminder regardless of other requirements
             if check_time_more_than(last_msg_timestamp, timedelta(days=3)):
@@ -279,7 +279,7 @@ class Reminders(commands.Cog):
         
         if isinstance(message.channel, discord.Thread) and message.channel.parent_id == SUPPORT_CHANNEL_ID:
             others_filter = not message.channel.locked and NEED_DEV_REVIEW_TAG_ID not in message.channel._applied_tags
-            owner_id = await get_post_creator_id(message.channel.id) or message.channel.owner_id
+            owner_id = await self.bot.get_owner_id(message.channel)
             message_author = message.author.id == owner_id
             if message_author and others_filter and await in_pending_posts(message.channel.id):
                 await remove_post_from_pending(message.channel.id)

--- a/SH/cogs/utility.py
+++ b/SH/cogs/utility.py
@@ -7,7 +7,7 @@ import asyncio
 import datetime
 import os
 from dotenv import load_dotenv
-from functions import remove_post_from_rtdr, get_post_creator_id, \
+from functions import remove_post_from_rtdr, \
                     generate_random_id, remove_post_from_pending
 from typing import Union, Literal, Callable, TYPE_CHECKING
 import re
@@ -236,13 +236,13 @@ class Utility(commands.Cog):
         await self.bot.send_log(ALERTS_THREAD_ID, action_id=action_id, post_mention=post.mention, tags=tags, context="/unsolve used")
 
     @staticmethod
-    async def one_of_mod_expert_op(interaction: discord.Interaction):
+    async def one_of_mod_expert_op(interaction: discord.Interaction[SHBot]):
         """  
         Checks if the interaction user is a Moderator or Community Expert or the creator of the post\n
         --Integrated with rtdr system
         """
         if isinstance(interaction.channel, discord.Thread) and interaction.channel.parent_id == SUPPORT_CHANNEL_ID:
-            owner_id = await get_post_creator_id(interaction.channel_id) or interaction.channel.owner_id
+            owner_id = await interaction.client.get_owner_id(interaction.channel)
             return bool(interaction.user.get_role(EXPERTS_ROLE_ID) or interaction.user.get_role(MODERATORS_ROLE_ID) or interaction.user.get_role(DEVELOPERS_ROLE_ID)) or interaction.user.id == owner_id
         else:
             return False
@@ -284,7 +284,7 @@ class Utility(commands.Cog):
         if not isinstance(interaction.channel, discord.Thread) or interaction.channel.parent_id != SUPPORT_CHANNEL_ID:
             await interaction.response.send_message(content=f"This command is only usable in a post in <#{SUPPORT_CHANNEL_ID}>", ephemeral=True)
             return
-        is_owner = user.id == interaction.channel.owner_id or user.id == await get_post_creator_id(interaction.channel_id)
+        is_owner = interaction.user.id == await self.bot.get_owner_id(interaction.channel)
         if is_owner:
             await interaction.response.send_message(f"{user.mention} is the owner of this post. Therefore they cannot be removed.", ephemeral=True)
             return
@@ -448,7 +448,7 @@ class Utility(commands.Cog):
         if ctx.channel.id in self.bot.incomplete_msg_posts:
             await ctx.reply("You cannot use this command as an automatic message was already sent.", ephemeral=True, delete_after=5)
             return
-        user_id = await get_post_creator_id(ctx.channel.id) or ctx.channel.owner_id
+        user_id = await self.bot.get_owner_id(ctx.channel)
         text_prefix = "## Incomplete support post\nHey"
         if ctx.author.get_role(EXPERTS_ROLE_ID) or ctx.author.get_role(MODERATORS_ROLE_ID) or ctx.author.get_role(DEVELOPERS_ROLE_ID):
             text_prefix = f"## Incomplete support post\nHey <@{user_id}>"
@@ -506,7 +506,7 @@ class Utility(commands.Cog):
 
         text_prefix = "Hey"
         if await self.is_mod_or_expert_or_dev(interaction=interaction):
-            user_id = await get_post_creator_id(interaction.channel_id) or interaction.channel.owner_id
+            user_id = await self.bot.get_owner_id(interaction.channel)
             text_prefix = f"Hey <@{user_id}>"
             await self.lock_unrelated_post(interaction.channel)
         else:

--- a/SH/cogs/utility.py
+++ b/SH/cogs/utility.py
@@ -242,7 +242,7 @@ class Utility(commands.Cog):
         --Integrated with rtdr system
         """
         if isinstance(interaction.channel, discord.Thread) and interaction.channel.parent_id == SUPPORT_CHANNEL_ID:
-            owner_id = await interaction.client.get_owner_id(interaction.channel)
+            owner_id = await interaction.client.get_post_owner_id(interaction.channel)
             return bool(interaction.user.get_role(EXPERTS_ROLE_ID) or interaction.user.get_role(MODERATORS_ROLE_ID) or interaction.user.get_role(DEVELOPERS_ROLE_ID)) or interaction.user.id == owner_id
         else:
             return False
@@ -284,7 +284,7 @@ class Utility(commands.Cog):
         if not isinstance(interaction.channel, discord.Thread) or interaction.channel.parent_id != SUPPORT_CHANNEL_ID:
             await interaction.response.send_message(content=f"This command is only usable in a post in <#{SUPPORT_CHANNEL_ID}>", ephemeral=True)
             return
-        is_owner = interaction.user.id == await self.bot.get_owner_id(interaction.channel)
+        is_owner = interaction.user.id == await self.bot.get_post_owner_id(interaction.channel)
         if is_owner:
             await interaction.response.send_message(f"{user.mention} is the owner of this post. Therefore they cannot be removed.", ephemeral=True)
             return
@@ -448,7 +448,7 @@ class Utility(commands.Cog):
         if ctx.channel.id in self.bot.incomplete_msg_posts:
             await ctx.reply("You cannot use this command as an automatic message was already sent.", ephemeral=True, delete_after=5)
             return
-        user_id = await self.bot.get_owner_id(ctx.channel)
+        user_id = await self.bot.get_post_owner_id(ctx.channel)
         text_prefix = "## Incomplete support post\nHey"
         if ctx.author.get_role(EXPERTS_ROLE_ID) or ctx.author.get_role(MODERATORS_ROLE_ID) or ctx.author.get_role(DEVELOPERS_ROLE_ID):
             text_prefix = f"## Incomplete support post\nHey <@{user_id}>"
@@ -506,7 +506,7 @@ class Utility(commands.Cog):
 
         text_prefix = "Hey"
         if await self.is_mod_or_expert_or_dev(interaction=interaction):
-            user_id = await self.bot.get_owner_id(interaction.channel)
+            user_id = await self.bot.get_post_owner_id(interaction.channel)
             text_prefix = f"Hey <@{user_id}>"
             await self.lock_unrelated_post(interaction.channel)
         else:

--- a/SH/cogs/waiting_for_reply.py
+++ b/SH/cogs/waiting_for_reply.py
@@ -5,7 +5,7 @@ from discord.ext import commands
 import asyncio
 import os
 from dotenv import load_dotenv
-from functions import generate_random_id, get_post_creator_id
+from functions import generate_random_id
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -46,7 +46,7 @@ class waiting_for_reply(commands.Cog):
         support = message.channel.parent
         wfr = support.get_tag(WAITING_FOR_REPLY_TAG_ID)
         applied_tags = message.channel._applied_tags
-        message_author_is_owner = message.author.id == message.channel.owner_id or message.author.id == await get_post_creator_id(message.channel.id)
+        message_author_is_owner = message.author.id == await self.bot.get_owner_id(message.channel)
         has_wfr = WAITING_FOR_REPLY_TAG_ID in applied_tags
         if message.id == message.channel.id or NEED_DEV_REVIEW_TAG_ID in applied_tags or UNANSWERED_TAG_ID in applied_tags or SOLVED_TAG_ID in applied_tags:
             return

--- a/SH/cogs/waiting_for_reply.py
+++ b/SH/cogs/waiting_for_reply.py
@@ -46,7 +46,7 @@ class waiting_for_reply(commands.Cog):
         support = message.channel.parent
         wfr = support.get_tag(WAITING_FOR_REPLY_TAG_ID)
         applied_tags = message.channel._applied_tags
-        message_author_is_owner = message.author.id == await self.bot.get_owner_id(message.channel)
+        message_author_is_owner = message.author.id == await self.bot.get_post_owner_id(message.channel)
         has_wfr = WAITING_FOR_REPLY_TAG_ID in applied_tags
         if message.id == message.channel.id or NEED_DEV_REVIEW_TAG_ID in applied_tags or UNANSWERED_TAG_ID in applied_tags or SOLVED_TAG_ID in applied_tags:
             return

--- a/SH/functions.py
+++ b/SH/functions.py
@@ -169,7 +169,7 @@ async def add_post_to_rtdr(post_id: int, user_id: int) -> None:
             await cu.execute(f"INSERT INTO readthedamnrules (post_id, user_id) VALUES (?, ?) ON CONFLICT (post_id) DO NOTHING", (post_id, user_id,))
             await conn.commit()
 
-async def get_post_creator_id(post_id: int) -> Optional[int]:
+async def _get_post_creator_id(post_id: int) -> Optional[int]:
     """  
     Get the id of whoever the post was created for if its part of readthedamnrules system
     """

--- a/SH/main.py
+++ b/SH/main.py
@@ -3,7 +3,7 @@ from discord.ext import commands, tasks
 from discord import app_commands
 import os
 from dotenv import load_dotenv
-from functions import setup_db
+from functions import setup_db, _get_post_creator_id
 import unittest, test_functions
 from pathlib import Path
 import time
@@ -123,6 +123,28 @@ class SHBot(commands.Bot):
                 solved_id=command.id
                 break
         return solved_id
+
+
+    async def get_owner_id(self, post: discord.Thread | app_commands.AppCommandThread) -> int:
+        """
+        Helper function to get the owner ID for the post. Returns `0` if not found.
+        """
+        if post.owner_id != self.user.id:
+            return post.owner_id
+
+        # Created by RTDR
+        owner_id = await _get_post_creator_id(post.id)
+        if owner_id is None:
+            left_paren_index = post.name.rfind("(")
+            if left_paren_index == -1:
+                return 0
+
+            # Example title: Support for @username (USER_ID)
+            try:
+                return int(post.name[left_paren_index + 1:len(post.name) - 1])
+            except (ValueError, IndexError):
+                return 0
+        return owner_id
 
     async def on_ready(self):
         print(f"Bot is ready. Logged in as {self.user.name}")

--- a/SH/main.py
+++ b/SH/main.py
@@ -125,9 +125,9 @@ class SHBot(commands.Bot):
         return solved_id
 
 
-    async def get_owner_id(self, post: discord.Thread | app_commands.AppCommandThread) -> int:
+    async def get_post_owner_id(self, post: discord.Thread | app_commands.AppCommandThread) -> int:
         """
-        Helper function to get the owner ID for the post. Returns `0` if not found.
+        Helper function to get the owner ID for a support post. Returns `0` if not found.
         """
         if post.owner_id != self.user.id:
             return post.owner_id


### PR DESCRIPTION
## What does this PR do?
This PR fixes RTDR owner_ids being unretrievable after being cleared from DB. This results in people not being to unsolve/solve posts.

Fix:
- Makes a helper function `get_owner_id`
- Make RTDR posts have `(USER_ID)` as it's suffix in the post title, so that we can retrieve the owner_id through the post title
- The helper function only checks the suffix when:
  - When the post is an RTDR post (i.e `user.id` == `post.owner_id`)
  - When `_get_post_creator_id` is None (i.e the owner_id is no longer in the DB)
 - Returns `0` if the owner_id could not be found.
  

See
- issue: <!-- Please include the issue number this PR is addressing like so: "- issue: #12". If there isn't an issue, please create one!--> #81 

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
- [ ] This PR is not a code change (i.e, README)
