### PR TITLE
Fix: Restore Pending Posts

### DIFF
--- a/SH/cogs/remind.py
+++ b/SH/cogs/remind.py
@@ -8,6 +8,7 @@ import asyncio
 from discord import ui
 from discord import app_commands
 from datetime import timedelta
+from time import perf_counter
 import os
 from dotenv import load_dotenv
 from typing import TYPE_CHECKING
@@ -127,10 +128,49 @@ class Reminders(commands.Cog):
         self.bot.add_view(CloseNowView())
 
     async def cog_load(self):
+        # Check that the bot was recently started (i.e pending_posts would be cleared from cache)
+        # And that pending posts is empty
+        if ((perf_counter() - self.bot.uptime) <= 5) and not self.bot.pending_posts:
+            await self.restore_pending_posts()
+
         self.reminders_loop.start()
 
     async def cog_unload(self):
         self.reminders_loop.cancel()
+
+    async def restore_pending_posts(self):
+        """
+        Restores pending_posts that were cleared from cache
+        when the bot was completely restarted.
+        """
+        suport_channel = self.bot.get_channel(SUPPORT_CHANNEL_ID) or await self.bot.fetch_channel(SUPPORT_CHANNEL_ID)
+
+        for post in await suport_channel.guild.active_threads():
+            if post.id in self.bot.pending_posts or not post.last_message_id:
+                continue
+
+            # posts must at least be a day old for a reminder to be sent!
+            if not check_time_more_than(snowflake_time(post.id).timestamp(), timedelta(days=1)):
+                continue
+
+            if not self.reminders_filter(post) or self.bot.user.id not in [member.id for member in post.members]:
+                continue
+
+            try:
+                last_message = post.last_message or await post.fetch_message(post.last_message_id)
+            except discord.HTTPException:
+                continue
+            
+            if last_message.author.id != self.bot.user.id or not last_message.flags.components_v2:
+                continue
+
+            for component in last_message.components:
+                if not isinstance(component, discord.Container):
+                    continue
+                for child in component.children:
+                    if isinstance(child, discord.TextDisplay) and "it seems like your last message was sent more than" in child.content:
+                        self.bot.add_post_to_pending(post.id, timestamp=int(last_message.created_at.timestamp()))
+                        break
 
     def get_reminder_next_iteration(self) -> str:
         """
@@ -372,6 +412,13 @@ class Reminders(commands.Cog):
 
         container = ui.Container(ui.TextDisplay(content[0:4000]))
         await interaction.followup.send(view=ui.LayoutView().add_item(container), ephemeral=True)
+
+    @reminders_cmd_group.command(name="restore_pending_posts", description="Manually restore pending posts. Note that this should already be called at startup")
+    @app_commands.checks.has_any_role(MODERATORS_ROLE_ID, EXPERTS_ROLE_ID, DEVELOPERS_ROLE_ID)
+    async def reminders_restore_pending_posts_cmd(self, interaction: discord.Interaction):
+        await interaction.response.defer(ephemeral=True)
+        await self.restore_pending_posts()
+        await interaction.followup.send(f"Success! Use `/debug global_cache` to check all current pending posts.", ephemeral=True)
 
 async def setup(bot: SHBot):
     await bot.add_cog(Reminders(bot))

--- a/SH/main.py
+++ b/SH/main.py
@@ -166,12 +166,17 @@ class SHBot(commands.Bot):
         self.rtdr_posts.pop(thread_id, None)
 
 
-    def add_post_to_pending(self, thread_id: int) -> None:
+    def add_post_to_pending(self, thread_id: int, *, timestamp: int | None = None) -> None:
         """
         Adds a post to the `pending_posts` cache and store the time it was inserted at.
+
+        Parameters
+        ----------
+        `timestamp`: `int`
+            When the post is added to pending. Defaults to the current timestamp.
         """
-        now = int(datetime.now(UTC).timestamp())
-        self.pending_posts[thread_id] = now
+        timestamp = timestamp or int(datetime.now(UTC).timestamp())
+        self.pending_posts[thread_id] = timestamp
 
     def remove_post_from_pending(self, thread_id: int) -> None:
         """


### PR DESCRIPTION
## What does this PR do?
This PR (partially) fixes #101 by restoring the posts at startup.

I say "partially" as there's an edge cases where we can't confirm whether something was previously in pending posts or not. The edge case being: The last message of the post is deleted OR the author of the last message is **not** the OP or SH. 

This is because we can only confirm if a post was previously in pending if we the last message is a **Reminder** message or that the last message was by the OP.

I don't think this is a huge problem, worse case the reminder gets sent again after 1/3 days. However, if it does become a huge issue, I'll have to think of a separate solution.

- issue: <!-- Please include the issue number this PR is addressing like so: "- issue: #12". If there isn't an issue, please create one!--> #101 

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
- [ ] This PR is not a code change (i.e, README)
